### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/lawvs/gitlab-event-types.git"
+    "url": "git+https://github.com/lawvs/gitlab-event-types.git"
   },
   "license": "MIT",
   "author": "lawvs",


### PR DESCRIPTION
## Summary

- update `package.json` repository metadata from the SSH GitHub URL to the public `git+https` URL
- leave runtime code, dependencies, lockfile, package version, and package contents unchanged

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build`
- direct `package.json` repository URL assertion
- `pnpm pack --dry-run --json --config.ignore-scripts=true`
- `git diff --check`

The repository's `test` script is the placeholder `echo "Error: no test specified" && exit 1`, so there is no project test suite to run.
